### PR TITLE
Fix analyzer issues

### DIFF
--- a/lib/ui/screens/account_screen/login_screen.dart
+++ b/lib/ui/screens/account_screen/login_screen.dart
@@ -158,7 +158,7 @@ class _LoginScreenState extends State<LoginScreen> {
       await AnnouncementService().syncBookmarksAfterLogin();
     } catch (e) {
       // Ignore sync errors - user can still use the app
-      print('Bookmark sync failed: $e');
+      debugPrint('Bookmark sync failed: $e');
     }
 
     if (!mounted) return;

--- a/lib/ui/screens/account_screen/signup_screen.dart
+++ b/lib/ui/screens/account_screen/signup_screen.dart
@@ -1,6 +1,5 @@
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:flutter/material.dart';
-import 'dart:developer';
 import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;

--- a/lib/ui/screens/annoucement_screen/announcement_detail_screen.dart
+++ b/lib/ui/screens/annoucement_screen/announcement_detail_screen.dart
@@ -75,11 +75,6 @@ class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
     }
   }
 
-  String _formatDate(DateTime? date) {
-    if (date == null) return 'ไม่ระบุ';
-    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
-  }
-
   String _formatDateOnly(DateTime? date) {
     if (date == null) return 'ไม่ระบุ';
     return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}';
@@ -165,7 +160,7 @@ class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
         borderRadius: BorderRadius.circular(12.r),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 8,
             offset: const Offset(0, 4),
           ),
@@ -278,7 +273,7 @@ class _AnnouncementDetailScreenState extends State<AnnouncementDetailScreen> {
                 border: Border.all(color: Colors.grey[200]!),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.05),
+                    color: Colors.black.withValues(alpha: 0.05),
                     blurRadius: 4,
                     offset: const Offset(0, 2),
                   ),

--- a/lib/ui/screens/annoucement_screen/announcements_screen.dart
+++ b/lib/ui/screens/annoucement_screen/announcements_screen.dart
@@ -206,8 +206,9 @@ class _AnnouncementScreenState extends State<AnnouncementScreen>
                                           child,
                                           loadingProgress,
                                         ) {
-                                          if (loadingProgress == null)
+                                          if (loadingProgress == null) {
                                             return child;
+                                          }
                                           return Center(
                                             child: CircularProgressIndicator(
                                               strokeWidth: 2,

--- a/lib/ui/screens/annoucement_screen/bookmarked_announcements_screen.dart
+++ b/lib/ui/screens/annoucement_screen/bookmarked_announcements_screen.dart
@@ -125,8 +125,9 @@ class _BookmarkedAnnouncementsScreenState
                                           child,
                                           loadingProgress,
                                         ) {
-                                          if (loadingProgress == null)
+                                          if (loadingProgress == null) {
                                             return child;
+                                          }
                                           return Center(
                                             child: CircularProgressIndicator(
                                               strokeWidth: 2,

--- a/lib/ui/screens/events_screen/event_detail_screen.dart
+++ b/lib/ui/screens/events_screen/event_detail_screen.dart
@@ -114,7 +114,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                     Container(
                       padding: EdgeInsets.all(12.w),
                       decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.2),
+                                color: Colors.white.withValues(alpha: 0.2),
                         borderRadius: BorderRadius.circular(15.r),
                       ),
                       child: Icon(Icons.event, size: 32.sp, color: Colors.white),
@@ -180,7 +180,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                         ),
                         SizedBox(height: 8.h),
                         Text(
-                          'ลงทะเบียนแล้ว ${enrolled}/${capacity} คน',
+                                  'ลงทะเบียนแล้ว $enrolled/$capacity คน',
                           style: TextStyle(
                             fontSize: 12.sp,
                             color: isFull ? Colors.red.shade700 : Colors.grey.shade700,
@@ -190,7 +190,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                       ] else ...[
                         // ไม่จำกัดจำนวน: แสดงเฉพาะจำนวนปัจจุบัน
                         Text(
-                          'ลงทะเบียนแล้ว ${enrolled} คน',
+                                  'ลงทะเบียนแล้ว $enrolled คน',
                           style: TextStyle(fontSize: 12.sp, color: Colors.grey.shade700),
                         ),
                       ],
@@ -298,7 +298,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                 Container(
                   padding: EdgeInsets.all(8.w),
                   decoration: BoxDecoration(
-                    color: color.withOpacity(0.1),
+                    color: color.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(10.r),
                   ),
                   child: Icon(icon, size: 20.sp, color: color),
@@ -355,7 +355,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                     Container(
                       padding: EdgeInsets.all(8.w),
                       decoration: BoxDecoration(
-                        color: Colors.blue.withOpacity(0.08),
+                        color: Colors.blue.withValues(alpha: 0.08),
                         borderRadius: BorderRadius.circular(10.r),
                       ),
                       child: Icon(Icons.play_arrow, size: 18.sp, color: Colors.blue),
@@ -401,7 +401,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                     Container(
                       padding: EdgeInsets.all(8.w),
                       decoration: BoxDecoration(
-                        color: Colors.red.withOpacity(0.08),
+                        color: Colors.red.withValues(alpha: 0.08),
                         borderRadius: BorderRadius.circular(10.r),
                       ),
                       child: Icon(Icons.stop, size: 18.sp, color: Colors.red),

--- a/lib/ui/screens/map_screen/map_screen.dart
+++ b/lib/ui/screens/map_screen/map_screen.dart
@@ -451,12 +451,12 @@ class _MapScreenState extends State<MapScreen> {
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
           decoration: BoxDecoration(
-            color: Colors.black.withOpacity(0.55),
+            color: Colors.black.withValues(alpha: 0.55),
             borderRadius: BorderRadius.circular(40),
-            border: Border.all(color: Colors.white.withOpacity(0.12), width: 1),
+            border: Border.all(color: Colors.white.withValues(alpha: 0.12), width: 1),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.4),
+                color: Colors.black.withValues(alpha: 0.4),
                 blurRadius: 10,
                 offset: const Offset(0, 4),
               ),
@@ -474,7 +474,7 @@ class _MapScreenState extends State<MapScreen> {
                   shape: BoxShape.circle,
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.red.withOpacity(0.6),
+                      color: Colors.red.withValues(alpha: 0.6),
                       blurRadius: 6,
                       offset: const Offset(0, 2),
                     ),
@@ -506,7 +506,7 @@ class _MapScreenState extends State<MapScreen> {
         borderRadius: BorderRadius.circular(14),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.08),
+            color: Colors.black.withValues(alpha: 0.08),
             blurRadius: 16,
             offset: const Offset(0, 6),
           ),
@@ -569,7 +569,7 @@ class _MapScreenState extends State<MapScreen> {
   Widget _buildErrorBanner() {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.orange.withOpacity(0.1),
+  color: Colors.orange.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(10),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
@@ -602,7 +602,7 @@ class _MapScreenState extends State<MapScreen> {
         borderRadius: BorderRadius.circular(14),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.08),
+            color: Colors.black.withValues(alpha: 0.08),
             blurRadius: 16,
             offset: const Offset(0, 8),
           ),
@@ -654,7 +654,7 @@ class _MapScreenState extends State<MapScreen> {
           borderRadius: BorderRadius.circular(16),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.15),
+              color: Colors.black.withValues(alpha: 0.15),
               blurRadius: 12,
               offset: const Offset(0, 6),
             ),

--- a/lib/ui/screens/profile_screen/profile_screen.dart
+++ b/lib/ui/screens/profile_screen/profile_screen.dart
@@ -99,7 +99,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       });
 
       try {
-        final mimeType = await image.mimeType;
+  final mimeType = image.mimeType;
         MediaType? mediaType = _mediaTypeFromMime(mimeType);
         mediaType ??= _mediaTypeFromPath(image.path);
 

--- a/lib/ui/screens/schedule_screen/schedule_screen.dart
+++ b/lib/ui/screens/schedule_screen/schedule_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 // Removed asset/mock usage; now only real service.
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:campusapp/core/routes.dart';
@@ -109,8 +108,9 @@ class _ScheduleScreenState extends State<ScheduleScreen>
     // ตัดวินาทีให้เหลือ HH:MM
     if (t.contains(':')) {
       final parts = t.split(':');
-      if (parts.length >= 2)
+      if (parts.length >= 2) {
         return '${parts[0].padLeft(2, '0')}:${parts[1].padLeft(2, '0')}';
+      }
     }
     return t;
   }

--- a/lib/ui/screens/setting_screen/setting_screen.dart
+++ b/lib/ui/screens/setting_screen/setting_screen.dart
@@ -129,10 +129,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
         Container(
           padding: EdgeInsets.all(8.w),
           decoration: BoxDecoration(
-            color:
-                value
-                    ? const Color(0xFF113F67).withOpacity(0.1)
-                    : Colors.grey.withOpacity(0.1),
+      color:
+        value
+          ? const Color(0xFF113F67).withValues(alpha: 0.1)
+          : Colors.grey.withValues(alpha: 0.1),
             borderRadius: BorderRadius.circular(8.r),
           ),
           child: Icon(
@@ -166,7 +166,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           value: value,
           onChanged: onChanged,
           activeColor: const Color(0xFF113F67),
-          activeTrackColor: const Color(0xFF113F67).withOpacity(0.3),
+          activeTrackColor: const Color(0xFF113F67).withValues(alpha: 0.3),
           inactiveThumbColor: Colors.grey[400],
           inactiveTrackColor: Colors.grey[300],
         ),

--- a/lib/ui/screens/started_screen/on_boarding_screen.dart
+++ b/lib/ui/screens/started_screen/on_boarding_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:campusapp/ui/screens/account_screen/login_screen.dart';
 import '../main_screen/main_screen.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -119,7 +118,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   page['subtitle']!,
                   style: TextStyle(
                     fontSize: 13.sp,
-                    color: Colors.white.withOpacity(0.70),
+                    color: Colors.white.withValues(alpha: 0.70),
                   ),
                   textAlign: TextAlign.center,
                 ),
@@ -205,10 +204,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       width: _currentPage == indexDot ? 14.w : 6.w,
                       height: 8.h,
                       decoration: BoxDecoration(
-                        color:
-                            _currentPage == indexDot
-                                ? Colors.white
-                                : Colors.white.withOpacity(0.5),
+            color:
+              _currentPage == indexDot
+                ? Colors.white
+                : Colors.white.withValues(alpha: 0.5),
                         borderRadius: BorderRadius.circular(4.r),
                       ),
                     ),

--- a/lib/ui/service/event_share_service.dart
+++ b/lib/ui/service/event_share_service.dart
@@ -20,7 +20,7 @@ class EventShareService {
     final desc = (event['description'] as String?)?.trim();
     if (desc == null || desc.isEmpty) return null;
     if (desc.length <= 160) return desc;
-    return desc.substring(0, 157) + '...';
+    return '${desc.substring(0, 157)}...';
   }
 
   /// Compose the message text for sharing

--- a/lib/ui/widgets/event_card.dart
+++ b/lib/ui/widgets/event_card.dart
@@ -11,7 +11,7 @@ class EventCard extends StatelessWidget {
     if (iso == null || iso.isEmpty) return '-';
     final dt = DateTime.tryParse(iso);
     if (dt == null) return '-';
-    final two = (int n) => n.toString().padLeft(2, '0');
+    String two(int n) => n.toString().padLeft(2, '0');
     return '${two(dt.day)}/${two(dt.month)}/${dt.year} ${two(dt.hour)}:${two(dt.minute)}';
   }
 
@@ -19,7 +19,7 @@ class EventCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: 5,
-      shadowColor: Colors.grey.withOpacity(0.3),
+      shadowColor: Colors.grey.withValues(alpha: 0.3),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.r)),
       child: Container(
         decoration: BoxDecoration(


### PR DESCRIPTION
Fixed bug

profile_screen.dart: Removed an unnecessary await on a String? (await_only_futures at line ~102). This could throw at runtime; it’s now correct.
Safe lint cleanups (no behavior change)
login_screen.dart: Replaced print with debugPrint to satisfy avoid_print.
signup_screen.dart: Removed unused import dart:developer.
on_boarding_screen.dart: Removed unused import shared_preferences and replaced Colors.white.withOpacity with withValues in 2 spots.
[announcements_screen.dart](vscode-file://vscode-app/c:/Users/ACER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and bookmarked_announcements_screen.dart: Wrapped single-line if returns in braces to satisfy curly_braces_in_flow_control_structures.
schedule_screen.dart:
Removed unnecessary import flutter/scheduler.dart.
Added braces for a single-line if in _formatTime.
announcement_detail_screen.dart:
Removed unused private method _formatDate.
Replaced several withOpacity usages in BoxShadows with withValues.
event_detail_screen.dart:
Fixed unnecessary braces in string interpolation for enrolled/capacity texts.
Replaced a few withOpacity usages with withValues.
map_screen.dart:
Replaced multiple withOpacity usages with withValues to clear deprecated_member_use infos.
setting_screen.dart:
Replaced withOpacity in container color and activeTrackColor with withValues.
event_card.dart:
Changed a local closure assigned to a variable into a local function to satisfy prefer_function_declarations_over_variables.
Replaced withOpacity with withValues on shadowColor.
event_share_service.dart:
Used interpolation instead of string concatenation for shortDescription (minor style cleanup).